### PR TITLE
Add accessor for SysProcAttr to Cmd shim

### DIFF
--- a/execshim/cmd.go
+++ b/execshim/cmd.go
@@ -1,6 +1,10 @@
 package execshim
 
-import "io"
+import (
+	"io"
+	"os/exec"
+	"syscall"
+)
 
 //go:generate counterfeiter -o exec_fake/fake_cmd.go . Cmd
 
@@ -11,4 +15,38 @@ type Cmd interface {
 	Wait() error
 	Run() error
 	CombinedOutput() ([]byte, error)
+
+	SysProcAttr() *syscall.SysProcAttr
+}
+
+type cmd struct {
+	*exec.Cmd
+}
+
+func (c *cmd) Start() error {
+	return c.Cmd.Start()
+}
+
+func (c *cmd) StdoutPipe() (io.ReadCloser, error) {
+	return c.Cmd.StdoutPipe()
+}
+
+func (c *cmd) StderrPipe() (io.ReadCloser, error) {
+	return c.Cmd.StderrPipe()
+}
+
+func (c *cmd) Wait() error {
+	return c.Wait()
+}
+
+func (c *cmd) Run() error {
+	return c.Run()
+}
+
+func (c *cmd) CombinedOutput() ([]byte, error) {
+	return c.Cmd.CombinedOutput()
+}
+
+func (c *cmd) SysProcAttr() *syscall.SysProcAttr {
+	return c.Cmd.SysProcAttr
 }

--- a/execshim/execshim.go
+++ b/execshim/execshim.go
@@ -6,16 +6,25 @@ package execshim
 import (
 	"context"
 	"os/exec"
+	"syscall"
 )
 
 type ExecShim struct{}
 
 func (sh *ExecShim) Command(name string, arg ...string) Cmd {
-	return exec.Command(name, arg...)
+	var c cmd
+	c.Cmd = exec.Command(name, arg...)
+	c.Cmd.SysProcAttr = &syscall.SysProcAttr{}
+
+	return &c
 }
 
 func (sh *ExecShim) CommandContext(ctx context.Context, name string, arg ...string) Cmd {
-	return exec.CommandContext(ctx, name, arg...)
+	var c cmd
+	c.Cmd = exec.CommandContext(ctx, name, arg...)
+	c.Cmd.SysProcAttr = &syscall.SysProcAttr{}
+
+	return &c
 }
 
 func (sh *ExecShim) LookPath(file string) (string, error) {


### PR DESCRIPTION
The exec shim supports the Command() function,
to obtain a Cmd object,
to which I (manually) add a SysProcAttr() method.

Added initialization for the indicated field,
for both Command and CommandContext in the execshim
(that is the shimmed constructor for Cmd type objects)

(there was a problem with `counterfeiter` at this point,
which prevented `go generate` creating the needed fake_cmd.go
inside exec_fake/; consequently, I manually edited the fake
as well)